### PR TITLE
Add netplan config backup and clean up

### DIFF
--- a/sh/network.sh
+++ b/sh/network.sh
@@ -70,6 +70,14 @@ echo -e $"interface=$ENS2\nbind-interfaces\nno-hosts\ndhcp-range=10.0.0.2,10.0.0
 systemctl restart dnsmasq
 
 echo Writing netplan config...
+
+# Backup the netplan directory
+cp -r /etc/netplan ./netplan.bak
+echo "Backed up existing netplan config to ./netplan.bak"
+
+# Delete all files in the netplan directory
+rm /etc/netplan/*.yaml
+
 rm /etc/netplan/00*
 printf "network:
   version: 2

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -78,7 +78,6 @@ echo "Backed up existing netplan config to ./netplan.bak"
 # Delete all files in the netplan directory
 rm /etc/netplan/*.yaml
 
-rm /etc/netplan/00*
 printf "network:
   version: 2
   renderer: networkd


### PR DESCRIPTION
To improve safety and clarity in network.sh, a backup of the current netplan config files has been added before any changes are made. This allows for easy recovery if any issues arise. Also, included is a clean-up step that removes all existing .yaml files in the netplan directory to avoid potential conflicts with the new configuration.