### PR TITLE
Network interface selection

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -19,7 +19,7 @@ mkdir -p install
 . ./sh/downloads.sh
 
 echo Running necessary steps as root via sudo...
-ACS_DOMAIN="$baseURL" REALM="$realm" sudo -E /bin/sh ./sh/as-root.sh
+ACS_DOMAIN="$baseURL" REALM="$realm" sudo -E /bin/bash ./sh/as-root.sh
 
 echo "Setting KUBECONFIG for use by k8s tools..."
 export KUBECONFIG="$(realpath ./install/k3s.yaml)"

--- a/sh/install-deps.sh
+++ b/sh/install-deps.sh
@@ -20,7 +20,7 @@ bash ./install/node-apt.sh
 
 apt-get install -y \
     wireguard g++ iptables-persistent dnsmasq krb5-user \
-    cmake libkrb5-dev nodejs jq
+    cmake libkrb5-dev nodejs jq dialog
 
 bash ./install/helm.sh
 bash ./install/flux.sh

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -70,6 +70,14 @@ echo -e $"interface=$ENS2\nbind-interfaces\nno-hosts\ndhcp-range=10.0.0.2,10.0.0
 systemctl restart dnsmasq
 
 echo Writing netplan config...
+
+# Backup the netplan directory
+cp -r /etc/netplan ./netplan.bak
+echo "Backed up existing netplan config to ./netplan.bak"
+
+# Delete all files in the netplan directory
+rm /etc/netplan/*.yaml
+
 rm /etc/netplan/00*
 printf "network:
   version: 2

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -29,6 +29,13 @@ ENS=$(dialog --menu "Select the SOUTHBOUND interface:" 0 0 0 "${options[@]}" 2>&
 # Cluster interface
 ENC=$(dialog --menu "Select the CLUSTER interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
 
+# Quit if any of the interfaces are not selected
+if [ -z "$ENN" ] || [ -z "$ENS" ] || [ -z "$ENC" ]
+then
+    echo "You must select all interfaces!" >&2
+    exit 1
+fi
+
 # Clear the screen
 clear
 

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -78,7 +78,6 @@ echo "Backed up existing netplan config to ./netplan.bak"
 # Delete all files in the netplan directory
 rm /etc/netplan/*.yaml
 
-rm /etc/netplan/00*
 printf "network:
   version: 2
   renderer: networkd

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -21,7 +21,7 @@ done <<< "$interfaces"
 
 
 # Northbound interface
-ENN=$(dialog --menu "Select the NORTHBOUND interface. If SSHing This must be the interface that:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
+ENN=$(dialog --menu "Select the NORTHBOUND interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
 
 # Southbound interface
 ENS=$(dialog --menu "Select the SOUTHBOUND interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)

--- a/sh/network.sh
+++ b/sh/network.sh
@@ -7,30 +7,34 @@ then
     exit 1
 fi
 
+# Run `ip -br l` command and store the list of available interfaces in a variable
+interfaces=$(ip -br l)
+
+# Parse the output to extract interface name, status, and MAC address
+options=()
+while read -r line; do
+  name=$(echo "$line" | awk '{print $1}')
+  status=$(echo "$line" | awk '{print $3}')
+  mac=$(echo "$line" | awk '{print $2}')
+  options+=("$name" "$status - $mac")
+done <<< "$interfaces"
+
+
 # Northbound interface
-ENN=$(ip -br l | awk '$1 ~ "enp" { print $1}' | sed -n 1p)
+ENN=$(dialog --menu "Select the NORTHBOUND interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
 
-# Southbound interface 1
-ENS1=$(ip -br l | awk '$1 ~ "enx" { print $1}' | sed -n 1p)
+# Southbound interface
+ENS=$(dialog --menu "Select the SOUTHBOUND interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
 
-# Southbound interface 2
-ENS2=$(ip -br l | awk '$1 ~ "enx" { print $1}' | sed -n 2p)
+# Cluster interface
+ENC=$(dialog --menu "Select the CLUSTER interface:" 0 0 0 "${options[@]}" 2>&1 >/dev/tty)
 
-if [ -z "$ENN" ]
-then
-  echo "Northbound interface could not be found"
-  exit 1
-fi
-if [ -z "$ENS1" ]
-then
-  echo "First southbound interface could not be found"
-  exit 1
-fi
-if [ -z "$ENS2" ]
-then
-  echo "Second southbound interface could not be found"
-  exit 1
-fi
+# Clear the screen
+clear
+
+echo Northbound: $ENN
+echo Southbound: $ENS
+echo Cluster: $ENC
 
 # Serial number
 SERIAL=$(dmidecode -s system-serial-number | tr [:upper:] [:lower:])
@@ -39,10 +43,6 @@ hostnamectl set-hostname fpcgw-${SERIAL}
 echo $(hostname)
 
 echo Configuring network...
-echo Adapters found:
-echo ENN: $ENN
-echo ENS1: $ENS1
-echo ENS2: $ENS2
 
 echo Setting iptables...
 # Allow all incoming connections
@@ -66,7 +66,7 @@ netfilter-persistent save
 iptables-legacy-save
 
 echo Configuring dnsmasq on the 10.0.0.1 interface...
-echo -e $"interface=$ENS2\nbind-interfaces\nno-hosts\ndhcp-range=10.0.0.2,10.0.0.150,12h" >"/etc/dnsmasq.conf"
+echo -e $"interface=$ENC\nbind-interfaces\nno-hosts\ndhcp-range=10.0.0.2,10.0.0.150,12h" >"/etc/dnsmasq.conf"
 systemctl restart dnsmasq
 
 echo Writing netplan config...
@@ -85,11 +85,11 @@ printf "network:
     $ENN:
       dhcp4: true
       critical: true
-    $ENS1:
+    $ENS:
       optional: true
       addresses:
         - 192.168.1.100/24
-    $ENS2:
+    $ENC:
       ignore-carrier: true
       addresses:
         - 10.0.0.1/24


### PR DESCRIPTION
This PR improves user experience by adding dialog-based interface selection in the network setup script. This way, users can directly select an interface from a list rather than having the script make the selection for them.

If the script is being run over a SSH connection and the SSH host's IP does not match the northbound interface's IP, an error message is displayed to the user. This prevents the `critical: true` flag from being added to the wrong interface and the SSH connection being dropped when the new netplan config is applied.

<img width="710" alt="image" src="https://github.com/AMRC-FactoryPlus/acs-edge-bootstrap/assets/114239316/7822c668-6e20-44b1-85c4-1c1f48138663">

In addition, the 'dialog' package has been added to the dependencies in the installation script to support the new interface selection feature. The other changes are refactoring in the code to replace hardcoded interface selections with the new dialog-based selection logic. This change provides a friendlier interface for users when configuring the network settings. 